### PR TITLE
Fix some minor issues with Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ python ./frames.py --help
 >> Options:
 >>   --output TEXT     Output file name or relative path. If not extension,
 >>                     defaults to --extension or JPEG if no extension is given.
->>   --width TEXT      Width of the output file. If none provided the width of
+>>   --width INTEGER   Width of the output file. If none provided the width of
 >>                     the image will be half the amount of frames calculated
 >>   --extension TEXT  Output file extension.
 >>   --ratio FLOAT     Get a frame every n seconds. Default=1.0
@@ -20,5 +20,5 @@ python ./frames.py --help
 
 ```
 
-Retrieve the average color of every frame from a video file and save it's representation to an image file.
-You can input an image to retrieve it's average color.
+Retrieve the average color of every frame from a video file and save its representation to an image file.  
+You can input an image to retrieve its average color.

--- a/frames.py
+++ b/frames.py
@@ -178,9 +178,9 @@ class AverageFrameColor:
 @click.command()
 @click.argument('filepath', required=True)
 @click.option('--output', help='Output file name or relative path. If not extension, defaults to --extension or JPEG if no extension is given.', required=False)
-@click.option('--width', help='Width of the output file. If none provided the width of the image will be half the amount of frames calculated')
+@click.option('--width', help='Width of the output file. If none provided the width of the image will be half the amount of frames calculated', type=int)
 @click.option('--extension', help='Output file extension.', required=False)
-@click.option('--ratio', help='Get a frame every n seconds. Default=1.0', default=1.0, required=False)
+@click.option('--ratio', help='Get a frame every n seconds. Default=1.0', default=1.0, required=False, type=float)
 @click.option('--show', default=True, help='Show image after processing.', required=False)
 def main(filepath: str, width: int, output: str, extension: str, show: bool, ratio) -> None:
     average = AverageFrameColor(filepath, width, output, extension, show, ratio)


### PR DESCRIPTION
On Python 3.7 on Windows whenever I specified `--width` it would throw an error, because the parameter was not casted to an `int` (but it was a `str`). I fixed that by using the `type=int` parameter for the option/argument setup.